### PR TITLE
make docker dependencies work in hyras example

### DIFF
--- a/examples/hyras/README.md
+++ b/examples/hyras/README.md
@@ -10,22 +10,3 @@ and the root project.
 ```
 docker compose -f examples/hyras/docker-compose.yml up -d
 ```
-
-Right now I can't figure out how to make the intsaller service wait until the db service is healthy.
-Thus, after the thing is running, check the logs. The installer might have complained that the
-db is not there. Then, invoke the installer manually, until that issue is resolved.
-
-```
-docker compose -f examples/hyras/docker-compose.yml run --rm installer
-```
-
-The same thing applies to the actual examples. I can't figure out a way, how they could `depend_on: installer`,
-in a way, that they wait until the installer has *finished*. 
-Hence, their default command is overwritten to just echo the command that one would need to actually run the tool.
-
-Long story short: To run one of the examples, with the `/examples/hyras` compose cluster running, you can:
-
-```
-cd examples/hyras
-docker compose run --rm de410890_loader python run.py
-```

--- a/examples/hyras/docker-compose.yml
+++ b/examples/hyras/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       - 5433:5432
     volumes:
       - ../../data/pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}'"]
+      interval: 50s
+      timeout: 10s
+      retries: 5
 
   installer:
     build:
@@ -19,12 +24,13 @@ services:
       dockerfile: Dockerfile
     links:
       - db
-    depends_on: 
-      - db 
+    depends_on:
+        db:
+            condition: "service_healthy"
     environment:
       METACATALOG_URI: postgresql://postgres:postgres@db:5432/metacatalog
       DATA_FILE_PATH: /data/raster
-      START_YEAR: 1950
+      START_YEAR: 2010
       END_YEAR: 2020
     command: ["python", "/src/pg_init/init.py"]
     volumes:
@@ -37,6 +43,9 @@ services:
       dockerfile: Dockerfile
     links:
       - db
+    depends_on:
+        installer:
+            condition: "service_completed_successfully"
     environment:
       METACATALOG_URI: postgresql://postgres:postgres@db:5432/metacatalog
     command: ["echo", "run the tool like 'docker compose run --rm loader python run.py'"]
@@ -56,6 +65,9 @@ services:
       dockerfile: Dockerfile
     links:
       - db
+    depends_on:
+        installer:
+            condition: "service_completed_successfully"
     environment:
       METACATALOG_URI: postgresql://postgres:postgres@db:5432/metacatalog
     command: ["echo", "run the tool like 'docker compose run --rm loader python run.py'"]
@@ -71,6 +83,9 @@ services:
       dockerfile: Dockerfile
     links:
       - db
+    depends_on:
+        installer:
+            condition: "service_completed_successfully"
     environment:
       METACATALOG_URI: postgresql://postgres:postgres@db:5432/metacatalog
     command: ["echo", "run the tool like 'docker compose run --rm loader python run.py'"]
@@ -85,6 +100,9 @@ services:
       dockerfile: Dockerfile
     links:
       - db
+    depends_on:
+        installer:
+            condition: "service_completed_successfully"
     environment:
       METACATALOG_URI: postgresql://postgres:postgres@db:5432/metacatalog
     command: ["echo", "run the tool like 'docker compose run --rm loader python run.py'"]


### PR DESCRIPTION
Added an health check to the db container, so the installer can wait for it to be healthy.
The further containers shall wait for the installer to be finished successfully. I suppose it works, but I don't know by now how to check, if all datasets are imported correctly.