### PR TITLE
Download DEM data in the example

### DIFF
--- a/examples/dem/README.md
+++ b/examples/dem/README.md
@@ -1,12 +1,7 @@
 # Copernicus DEM example
 
 This example incldues a installer service that loads an example Copernicus 30m-DEM for Baden-Württemberg
-to metacatalog. 
-
-Other than the HYRAS example, the script **does not download** the DEM to the folder, as you need to authenticate
-to be able to download. Once you have a DEM, put it in the `./data/raster/DEM` folder, as the upload notebook uses
-a hard-coded `/data/raster/DEM/*.tif` path (mounted inside the container) to find the files. If you store the data 
-somewhere else, you need to change the mount point in the docker compose file.
+to metacatalog.
 
 To install the example, run:
 
@@ -31,5 +26,5 @@ Long story short: To run one of the examples, with the `/examples/dem` compose c
 
 ```
 cd examples/dem
-docker compose run --rm dede210080_loader python run.py
+docker compose run --rm de210080_loader python run.py
 ```

--- a/examples/dem/README.md
+++ b/examples/dem/README.md
@@ -1,7 +1,6 @@
 # Copernicus DEM example
 
-This example incldues a installer service that loads an example Copernicus 30m-DEM for Baden-Württemberg
-to metacatalog.
+This example incldues a installer service that loads an example Copernicus 30m-DEM for Baden-Württemberg to metacatalog.
 
 To install the example, run:
 

--- a/examples/dem/docker-compose.yml
+++ b/examples/dem/docker-compose.yml
@@ -24,6 +24,10 @@ services:
     environment:
       METACATALOG_URI: postgresql://postgres:postgres@db:5432/metacatalog
       DATA_FILE_PATH: /data/raster
+      LAT_MIN: 47
+      LAT_MAX: 49
+      LON_MIN: 7
+      LON_MAX: 10
     command: ["python", "/src/pg_init/init.py"]
     volumes:
       - ../../data/raster:/data/raster

--- a/examples/dem/init.sh
+++ b/examples/dem/init.sh
@@ -3,6 +3,31 @@
 # this is the first thing that is run when the installer service is started
 # here we can use papermill to run the notebook for upload
 
+# download the Copernicus GLO-30 dem for the given extent
+mkdir -p ${DATA_FILE_PATH}/DEM
+cd ${DATA_FILE_PATH}/DEM
+for (( lat=$LAT_MIN; lat<=$LAT_MAX; lat++ ))
+do
+	for (( lon=$LON_MIN; lon<=$LON_MAX; lon++ ))
+	do
+		# Download the DEM data
+		lat_leading_zeros=$(printf "%02d" $lat)
+		lon_leading_zeros=$(printf "%03d" $lon)
+		name=Copernicus_DSM_10_N${lat_leading_zeros}_00_E${lon_leading_zeros}_00
+       	wget --no-clobber https://prism-dem-open.copernicus.eu/pd-desk-open-access/prismDownload/COP-DEM_GLO-30-DGED__2023_1/${name}.tar
+		
+		# Extract the DEM data
+		tar -xf ${name}.tar
+
+		# Move the .tif file to the current directory
+		mv ${name}/DEM/${name}_DEM.tif .
+
+		# Remove the files
+		rm ${name}.tar
+		rm -r ${name}
+	done
+done
+
 # install papermill and jupyter to run the examples
 pip install papermill jupyter
 


### PR DESCRIPTION
I added automatic download of DEM data from Copernicus to the `init.sh` script.  
It is possible to define the area for which to download the DEM data via environment variables in the `docker-compose` file.

When I run the script locally the download works.  
@mmaelicke at the moment the download is not executed when I install the example as described:
```bash
cd examples/dem
docker compose up -d
```
I don't know why that is the case, I think you should have a better idea about that.